### PR TITLE
fix: JobSelection dropdown 높이 제한

### DIFF
--- a/interview_partner/src/component/css/JobSelection.css
+++ b/interview_partner/src/component/css/JobSelection.css
@@ -39,6 +39,7 @@
     min-width: 180px;
     max-width: 240px;
     text-align: center;
+    color: black;
   }
   
   .subJobDropdown {
@@ -51,6 +52,8 @@
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     z-index: 1;
     min-width: 180px;
+    max-height: 200px;
+    overflow-y: auto;
   }
   
   .subJobItem {


### PR DESCRIPTION
JobSelection.css 수정 :
JobSelection.js에서 보이는 드롭다운 메뉴의 높이가 제한되지 않아 사용자가 전체 페이지를 스크롤해야 했던 문제를, 드롭다운에 높이 제한을 설정하여 수정 & 글자 검정으로 수정